### PR TITLE
fix exit status

### DIFF
--- a/t/author-changelog.t
+++ b/t/author-changelog.t
@@ -21,7 +21,7 @@ my $failno = 0;
 
 END {
     print "1..$testno\n";
-    exit $failno == 0 ? 0 : 1;
+    exit($failno == 0 ? 0 : 1);
 }
 
 # Search for changelog files.


### PR DESCRIPTION
`exit` has higher precedence than `?:` and `==`, so `exit $failno == 0 ? 0 : 1` parses as `(exit $failno) == 0 ? 0 : 1`, which is not what was intended.